### PR TITLE
Improve color styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,15 +10,21 @@ ANIMAL_NAMES = [
     'Lepre', 'Capriolo', 'Bufalo', 'Cammello', 'Cobra'
 ]
 
+COLORS = [
+    '#EF4444', '#10B981', '#3B82F6', '#F59E0B', '#8B5CF6',
+    '#EC4899', '#F87171', '#34D399', '#FBBF24', '#14B8A6'
+]
+
 players = [f'Player {i}' for i in range(1, 9)]
 teams = []
 current_match = None
 ranking = {}
 
 class Team:
-    def __init__(self, name, players):
+    def __init__(self, name, players, color):
         self.name = name
         self.players = players
+        self.color = color
 
 class Match:
     def __init__(self, team_a, team_b):
@@ -39,8 +45,14 @@ class Match:
 def get_ranking():
     data = []
     for name, games_won in ranking.items():
-        initials = ''.join([w[0] for w in next(t.players for t in teams if t.name == name)])
-        data.append({'name': name, 'games': games_won, 'initials': initials})
+        team_obj = next(t for t in teams if t.name == name)
+        initials = ''.join([w[0] for w in team_obj.players])
+        data.append({
+            'name': name,
+            'games': games_won,
+            'initials': initials,
+            'color': team_obj.color
+        })
     data.sort(key=lambda x: x['games'], reverse=True)
     return data
 
@@ -97,8 +109,10 @@ def shuffle():
     random.shuffle(players)
     teams = []
     names = random.sample(ANIMAL_NAMES, len(players)//2)
+    color_pool = random.sample(COLORS, len(players)//2)
     for i in range(0, len(players), 2):
-        team = Team(names[i//2], [players[i], players[i+1]])
+        color = color_pool[i//2 % len(color_pool)]
+        team = Team(names[i//2], [players[i], players[i+1]], color)
         teams.append(team)
     session['shuffling'] = True
     return redirect(url_for('admin'))

--- a/static/style.css
+++ b/static/style.css
@@ -1,11 +1,86 @@
-body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f2f2f2; }
-.container { padding: 20px; max-width: 400px; margin: auto; background: #fff; min-height: 100vh; }
-h2 { text-align: center; }
-form { margin: 10px 0; }
-button { padding: 10px; width: 100%; margin-top: 5px; }
-ul { list-style: none; padding: 0; }
-#teams-list li { padding: 5px 0; border-bottom: 1px solid #ddd; }
-#scoreboard { margin: 20px 0; padding: 10px; background: #eee; }
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(135deg, #4e54c8, #8f94fb);
+  color: #fff;
+}
+
+.container {
+  padding: 20px;
+  max-width: 480px;
+  margin: auto;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  min-height: 100vh;
+  backdrop-filter: blur(4px);
+}
+
+h2 {
+  text-align: center;
+}
+
+form {
+  margin: 10px 0;
+}
+
+button {
+  padding: 10px;
+  width: 100%;
+  margin-top: 5px;
+  border: none;
+  border-radius: 4px;
+  background: #4e54c8;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+#teams-list li {
+  padding: 5px 8px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  color: #fff;
+}
+
+#scoreboard {
+  margin: 20px 0;
+  display: flex;
+  gap: 10px;
+}
+
+.team-score {
+  flex: 1;
+  padding: 10px;
+  border-radius: 8px;
+  color: #fff;
+  text-align: center;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  color: #333;
+}
+
+th, td {
+  padding: 8px;
+  border: 1px solid #ddd;
+}
+
+th {
+  background: #4e54c8;
+  color: #fff;
+}
 @media (max-width: 480px) {
   .container { padding: 10px; }
   button { font-size: 16px; }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -22,7 +22,7 @@
 <h3>Teams</h3>
 <ul id="teams-list">
   {% for t in teams %}
-  <li>{{ t.name }}: {{ t.players[0] }} &amp; {{ t.players[1] }}</li>
+  <li style="background: {{ t.color }}; color: #fff">{{ t.name }}: {{ t.players[0] }} &amp; {{ t.players[1] }}</li>
   {% endfor %}
 </ul>
 <form method="post" action="/start_match">
@@ -44,10 +44,10 @@
 {% if current_match %}
 <h3>Current Match: {{ current_match.team_a.name }} vs {{ current_match.team_b.name }}</h3>
 <div id="scoreboard">
-  <div>
+  <div class="team-score" style="background: {{ current_match.team_a.color }}">
     {{ current_match.team_a.name }}: <span id="score_a">{{ current_match.games_a }}</span> games
   </div>
-  <div>
+  <div class="team-score" style="background: {{ current_match.team_b.color }}">
     {{ current_match.team_b.name }}: <span id="score_b">{{ current_match.games_b }}</span> games
   </div>
 </div>
@@ -73,7 +73,7 @@ setInterval(updateScore, 2000);
 <table>
   <tr><th>Team</th><th>Games Won</th></tr>
   {% for r in ranking %}
-  <tr><td>{{ r.name }} ({{ r.initials }})</td><td>{{ r.games }}</td></tr>
+  <tr style="background: {{ r.color }}; color: #fff"><td>{{ r.name }} ({{ r.initials }})</td><td>{{ r.games }}</td></tr>
   {% endfor %}
 </table>
 {% endif %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -6,7 +6,7 @@
 <h3>Teams</h3>
 <ul id="teams-list">
   {% for t in teams %}
-  <li>{{ t.name }}: {{ t.players[0] }} &amp; {{ t.players[1] }}</li>
+  <li style="background: {{ t.color }}; color: #fff">{{ t.name }}: {{ t.players[0] }} &amp; {{ t.players[1] }}</li>
   {% endfor %}
 </ul>
 {% else %}
@@ -15,10 +15,10 @@
 {% if current_match %}
 <h3>Current Match: {{ current_match.team_a.name }} vs {{ current_match.team_b.name }}</h3>
 <div id="scoreboard">
-  <div>
+  <div class="team-score" style="background: {{ current_match.team_a.color }}">
     {{ current_match.team_a.name }}: <span id="score_a">{{ current_match.games_a }}</span> games
   </div>
-  <div>
+  <div class="team-score" style="background: {{ current_match.team_b.color }}">
     {{ current_match.team_b.name }}: <span id="score_b">{{ current_match.games_b }}</span> games
   </div>
 </div>
@@ -38,7 +38,7 @@ setInterval(updateScore, 2000);
 <table>
   <tr><th>Team</th><th>Games Won</th></tr>
   {% for r in ranking %}
-  <tr><td>{{ r.name }} ({{ r.initials }})</td><td>{{ r.games }}</td></tr>
+  <tr style="background: {{ r.color }}; color: #fff"><td>{{ r.name }} ({{ r.initials }})</td><td>{{ r.games }}</td></tr>
   {% endfor %}
 </table>
 {% endif %}


### PR DESCRIPTION
## Summary
- introduce colorful palette and team colors
- redesign CSS for vibrant gradient theme
- colorize team and scoreboard elements
- display ranking rows with team color backgrounds

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68541cfc28b48327971a76f62b058d25